### PR TITLE
Fix missing scroll plugin

### DIFF
--- a/app/components/parallaxanimation.tsx
+++ b/app/components/parallaxanimation.tsx
@@ -2,8 +2,9 @@
 import { useEffect, useRef } from 'react';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { ScrollToPlugin } from 'gsap/ScrollToPlugin';
 
-gsap.registerPlugin(ScrollTrigger);
+gsap.registerPlugin(ScrollTrigger, ScrollToPlugin);
 
 const ParallaxAnimation = () => {
   const mainRef = useRef(null);
@@ -13,7 +14,6 @@ const ParallaxAnimation = () => {
 
   useEffect(() => {
     const arrowBtn = mainRef.current as HTMLElement | null;
-    const arrowBtnElement = arrowBtn?.querySelector('#arrow-btn');
 
     const tl = gsap.timeline({
       scrollTrigger: {


### PR DESCRIPTION
## Summary
- register `ScrollToPlugin` so the arrow scroll animation works
- remove unused query for the arrow button

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68436e601bf48328a21819f8b4df5f07