### PR TITLE
Fix asset path and add basic test setup

### DIFF
--- a/app/components/__tests__/parallaxanimation.test.tsx
+++ b/app/components/__tests__/parallaxanimation.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import ParallaxAnimation from '../parallaxanimation';
+
+describe('ParallaxAnimation', () => {
+  it('renders the arrow button', () => {
+    const { container } = render(<ParallaxAnimation />);
+    expect(container.querySelector('#arrow-btn')).toBeInTheDocument();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -154,7 +154,7 @@
   }
 
   .splash-id:hover {
-    scale: 2;
+    transform: scale(2);
     opacity: 1;
     transition: 150ms linear;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,8 +63,7 @@ export default function Home() {
     const yPosition = (screen - elementHeight) / 2;
     const scale = screen > 800 ? "0.65" : "0.45";
 
-    // Quick fade-in animation at the start
-    // Remove the immediate fade-in and let the timeline handle it
+    // Set initial state; the timeline will handle the fade-in animation
     gsap.set(model.current, { opacity: 0, y: yPositionTop, scale: 1, rotation: 0 });
     
     const timeline = gsap.timeline({
@@ -115,7 +114,8 @@ export default function Home() {
         <nav>
           <div className="nav">
             <div className="nav-links" style={{ gap: "1rem" }}>
-              <Image src="/coldsmoke-logo.png" alt="Cold Smoke Logo" width={60} height={60} style={{ width: "auto", height: "60px" }} />
+              {/* Logo filename uses camel case */}
+              <Image src="/coldSmoke-logo.png" alt="Cold Smoke Logo" width={60} height={60} style={{ width: "auto", height: "60px" }} />
             </div>
             <div className="nav-links" id="links">
               <button>products</button>
@@ -298,8 +298,8 @@ export default function Home() {
                   setTimer(2500);
                 }}
                 style={{
-                  opacity: imageIndex == 0 ? "1" : " ",
-                  scale: imageIndex == 0 ? "1.6" : " ",
+                  opacity: imageIndex == 0 ? "1" : "",
+                  transform: imageIndex == 0 ? "scale(1.6)" : "scale(1)",
                 }}
               ></div>
               <div
@@ -309,8 +309,8 @@ export default function Home() {
                   setTimer(2500);
                 }}
                 style={{
-                  opacity: imageIndex == 1 ? "1" : " ",
-                  scale: imageIndex == 1 ? "1.6" : " ",
+                  opacity: imageIndex == 1 ? "1" : "",
+                  transform: imageIndex == 1 ? "scale(1.6)" : "scale(1)",
                 }}
               ></div>
               <div
@@ -320,8 +320,8 @@ export default function Home() {
                   setTimer(2500);
                 }}
                 style={{
-                  opacity: imageIndex == 2 ? "1" : " ",
-                  scale: imageIndex == 2 ? "1.6" : " ",
+                  opacity: imageIndex == 2 ? "1" : "",
+                  transform: imageIndex == 2 ? "scale(1.6)" : "scale(1)",
                 }}
               ></div>
               <div
@@ -331,16 +331,16 @@ export default function Home() {
                   setTimer(2500);
                 }}
                 style={{
-                  opacity: imageIndex == 3 ? "1" : " ",
-                  scale: imageIndex == 3 ? "1.6" : " ",
+                  opacity: imageIndex == 3 ? "1" : "",
+                  transform: imageIndex == 3 ? "scale(1.6)" : "scale(1)",
                 }}
               ></div>
               <div
                 className="splash-id"
                 onClick={() => setImageIndex(4)}
                 style={{
-                  opacity: imageIndex == 4 ? "1" : " ",
-                  scale: imageIndex == 4 ? "1.6" : " ",
+                  opacity: imageIndex == 4 ? "1" : "",
+                  transform: imageIndex == 4 ? "scale(1.6)" : "scale(1)",
                 }}
               ></div>
             </div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next build && next export"
+    "export": "next build && next export",
+    "test": "jest"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
@@ -22,6 +23,11 @@
     "@types/react-dom": "^18.3.7",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/jest-dom": "^6.4.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- fix the logo path case sensitivity
- correct CSS transform scaling
- update stale GSAP fade-in comment
- change inline `scale` styles to `transform`
- add Jest config with a basic test for `ParallaxAnimation`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436e5fd958832896367a254af9fee2